### PR TITLE
lowercase labels

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -33,7 +33,7 @@
          ],
          "author": "Wallaby.js",
          "labels": [
-            "scraptchpad",
+            "scratchpad",
             "playground",
             "javascript",
             "typescript",

--- a/packages.json
+++ b/packages.json
@@ -35,9 +35,9 @@
          "labels": [
             "scraptchpad",
             "playground",
-            "JavaScript",
-            "TypeScript",
-            "REPL"
+            "javascript",
+            "typescript",
+            "repl"
          ],
          "readme": "http://quokkajs.com/sublime/readme.md",
          "homepage": "http://quokkajs.com",


### PR DESCRIPTION
Hi, I maintain the Sublime Text [package control channel](https://github.com/wbond/package_control_channel) and it's new [website](https://packages.sublimetext.io). We've been doing some quality control on package labels recently and the Quokka package stands out because the labels are not lowercase. For instance, this is on the old site, it's the only package with the JavaScript label: https://packagecontrol.io/browse/labels/JavaScript. Whereas of course there are dozens for [javascript](https://packagecontrol.io/browse/labels/javascript). 

We've got [new documentation](https://docs.sublimetext.io/guide/package-control/submitting.html#what-labels-to-use) that covers this. This PR would bring your package in line with those new guidelines, and should make it easier for people to find it.

Edit: fixed a typo in scratchpad